### PR TITLE
refactor: nome dos diretórios

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Before starting :checkered_flag:, you need to have [Git](https://git-scm.com) an
 
 ```bash
 # Clone this project
-$ git clone https://github.com/{{YOUR_GITHUB_USERNAME}}/padronização-de-readme-de-projeto
+$ git clone https://github.com/{{YOUR_GITHUB_USERNAME}}/padronizacaoReadme
 
 # Access
-$ cd padronização-de-readme-de-projeto
+$ cd padronizacaoReadme
 
 # Install dependencies
 $ yarn


### PR DESCRIPTION
O nome dos diretórios está divergente ao realizar o clone com o especificado no readme